### PR TITLE
Fix raw-buffer range

### DIFF
--- a/src/cljs_bach/synthesis.cljs
+++ b/src/cljs_bach/synthesis.cljs
@@ -151,7 +151,7 @@
         frame-count (* sample-rate duration)
         buffer (.createBuffer context 1 frame-count sample-rate)
         data (.getChannelData buffer 0)]
-    (doseq [i (range sample-rate)]
+    (doseq [i (range frame-count)]
       (aset data i (generate-bit! i)))
     buffer))
 


### PR DESCRIPTION
Noticed while fiddling with finite noise sequences. Apparently `raw-buffer` was ignoring duration altogether